### PR TITLE
Add Autopublish Support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,7 @@ from discord.ext.commands import Bot
 from jsondb import JSONDB
 
 TOKEN = os.getenv("TOKEN")
-COGS = ('cogs.watchlist', 'cogs.points', 'cogs.autodelete')
+COGS = ('cogs.watchlist', 'cogs.points', 'cogs.autodelete', 'cogs.autopublish')
 
 
 class Monodrone(Bot):

--- a/cogs/autopublish.py
+++ b/cogs/autopublish.py
@@ -14,7 +14,7 @@ class AutoPublish(commands.Cog):
     async def on_message(self, message):
         if not self.bot.is_ready():
             return
-        if not message.channel.id in self.autopublish_channels:
+        if message.channel.id not in self.autopublish_channels:
             return
         await asyncio.sleep(0.5)  
         await message.publish()
@@ -28,7 +28,7 @@ class AutoPublish(commands.Cog):
         embed.description = '\n'.join(f"<#{channel}>"
                                       for channel in self.autopublish_channels) \
                             or "No active channels."
-        embed.set_footer(text="Use \".autopublish add #channel #\" to add a channel rule, "
+        embed.set_footer(text="Use \".autopublish add #channel\" to add a channel rule, "
                               "or \".autopublish remove #channel\" to remove one.")
         await ctx.send(embed=embed)
 

--- a/cogs/autopublish.py
+++ b/cogs/autopublish.py
@@ -14,7 +14,7 @@ class AutoPublish(commands.Cog):
     async def on_message(self, message):
         if not self.bot.is_ready():
             return
-        if not message.channel.id in ANNOUNCEMENT_CHANNELS:
+        if not message.channel.id in self.autopublish_channels:
             return
         await asyncio.sleep(0.5)  
         await message.publish()

--- a/cogs/autopublish.py
+++ b/cogs/autopublish.py
@@ -36,7 +36,7 @@ class AutoPublish(commands.Cog):
     @commands.has_role(constants.MOD_ROLE_ID)
     async def autopublish_add(self, ctx, channel: discord.TextChannel):
         """Adds or updates an autopublish rule for the given channel."""
-        self.autodelete_channels[channel.id] = True
+        self.autopublish_channels[channel.id] = True
         self.bot.db.jset("autopublish", self.autopublish_channels)
         await ctx.send(f"Okay, added autopublish rule to publish messages in {channel.mention}.")
 

--- a/cogs/autopublish.py
+++ b/cogs/autopublish.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import discord
+from discord.ext import commands
+
+import constants
+
+class AutoPublish(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.autopublish_channels = bot.db.jget("autopublish", {})
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if not self.bot.is_ready():
+            return
+        if not message.channel.id in ANNOUNCEMENT_CHANNELS:
+            return
+        await asyncio.sleep(0.5)  
+        await message.publish()
+        
+    # ==== commands ====
+    @commands.group(invoke_without_command=True)
+    @commands.has_role(constants.MOD_ROLE_ID)
+    async def autopublish(self, ctx):
+        """Shows all channels with active autopublish."""
+        embed = discord.Embed(colour=0x60AFFF, title="Active Autopublish Channels")
+        embed.description = '\n'.join(f"<#{channel}>"
+                                      for channel in self.autopublish_channels) \
+                            or "No active channels."
+        embed.set_footer(text="Use \".autopublish add #channel #\" to add a channel rule, "
+                              "or \".autopublish remove #channel\" to remove one.")
+        await ctx.send(embed=embed)
+
+    @autopublish.command(name='add')
+    @commands.has_role(constants.MOD_ROLE_ID)
+    async def autopublish_add(self, ctx, channel: discord.TextChannel):
+        """Adds or updates an autopublish rule for the given channel."""
+        self.autodelete_channels[channel.id] = True
+        self.bot.db.jset("autopublish", self.autopublish_channels)
+        await ctx.send(f"Okay, added autopublish rule to publish messages in {channel.mention}.")
+
+    @autopublish.command(name='remove')
+    @commands.has_role(constants.MOD_ROLE_ID)
+    async def autopublish_remove(self, ctx, channel: discord.TextChannel):
+        """Removes an autopublish rule from a channel."""
+        if channel.id not in self.autopublish_channels:
+            return await ctx.send(f"{channel.mention} has no autopublish rule.")
+        del self.autopublish_channels[channel.id]
+        self.bot.db.jset("autopublish", self.autopublish_channels)
+        await ctx.send(f"Okay, removed autopublish rule from {channel.mention}.")
+
+
+def setup(bot):
+    bot.add_cog(AutoPublish(bot))


### PR DESCRIPTION
`.autopublish`
`.autopublish_add <channel mention>`
`.autopublish_remove <channel mention>`

Simply allows you to add channels to auto-publish posts to reduce the need for manual publishing. The bot will need Manage Messages and Send Messages permissions in the added channels in order to publish.