### PR TITLE
Various fixes and improvements

### DIFF
--- a/cogs/lookingforgroup.py
+++ b/cogs/lookingforgroup.py
@@ -734,7 +734,7 @@ class LookingForGroup(commands.Cog):
         self.lfg_timers = bot.db.jget("lookingforgroup", {})
 
     def cog_load(self):
-        self.bot.add_view(PostedView(bot=self.bot))
+        self.bot.add_view(PostedView(bot=self.bot, lfg_timers=self.lfg_timers))
 
         self.cleanup_timers.start()
 


### PR DESCRIPTION
- Adds a confirmation when going to delete a post
- Adds a reminder that there is a cooldown after posting, that doesn't go away by deleting it
- Fixes the reset timer commands
- No longer erases previously filled in fields when editing before posting
- Logs manually deleted submissions in the logging channel